### PR TITLE
Fix dependency detection recursion

### DIFF
--- a/src/entity-faker.ts
+++ b/src/entity-faker.ts
@@ -110,7 +110,7 @@ export class EntityFaker<T extends ObjectLiteral = ObjectLiteral> {
             const dependencyRelations = entityMetadata.manyToOneRelations.slice();
             outer: for (const oneToOneRelation of entityMetadata.oneToOneRelations) {
                 for (const joinColumn of oneToOneRelation.joinColumns) {
-                    if (joinColumn.target !== this.entityClass) {
+                    if (joinColumn.target !== entityMetadata.target) {
                         continue outer;
                     }
                 }


### PR DESCRIPTION
## Summary
- correct recursive dependency detection by checking join column target using current entity metadata

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611ec9502c8333b494b61baaacff27